### PR TITLE
Redirect outputs to GITHUB_OUTPUT

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,17 +5,17 @@ BASE_BRANCH="remotes/origin/$1"
 PATHSPEC=${@:2}
 FORK_POINT_SHA=$(git merge-base --fork-point $BASE_BRANCH || git merge-base $BASE_BRANCH HEAD)
 
-echo ::set-output name=fork_point_sha::$FORK_POINT_SHA
+echo "fork_point_sha=$FORK_POINT_SHA" >>"$GITHUB_OUTPUT"
 
 function check() {
 
   if [[ -z "$(git diff --name-only $FORK_POINT_SHA $PATHSPEC)" ]];
   then
     echo "Detected no changes on $PATHSPEC since $FORK_POINT_SHA"
-    echo ::set-output name=changed::false
+    echo "changed=false" >>"$GITHUB_OUTPUT"
   else
     echo "Detected changes on $PATHSPEC since $FORK_POINT_SHA"
-    echo ::set-output name=changed::true
+    echo "changed=true" >>"$GITHUB_OUTPUT"
   fi
 }
 


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/